### PR TITLE
Fix typo: Action sequence instead of Actions sequence

### DIFF
--- a/webdriver-spec.html
+++ b/webdriver-spec.html
@@ -7381,7 +7381,7 @@ is also removed.
 
 <ol>
  <li><p>Let <var>type</var> be the result of <a>getting a property</a>
-  named <code>type</code> from <var>actions sequence</var>.
+  named <code>type</code> from <var>action sequence</var>.
 
  <li><p>If <var>type</var> is
   not <code>"key"</code>, <code>"pointer"</code>,


### PR DESCRIPTION
Section 17 - Actions always refers to *action sequence*s; so fix a type and change *actions sequence* to *action sequence*.